### PR TITLE
Prevent SIGFPE from modulo by zero on extremely short audio files.

### DIFF
--- a/src/wavalyzer/main.cpp
+++ b/src/wavalyzer/main.cpp
@@ -217,6 +217,9 @@ int main(int argc, char* argv[])
         int ms_step = static_cast<int>(conf.ms_step);
 
         int report_ms_interval = total_ms / (20 * ms_step);
+        // Prevent a SIGFPE if the input file is short enough to make this 0
+        if (report_ms_interval == 0)
+            report_ms_interval = 1;
         float ms_per_window = window_size / ms_samples;
 
         cout << "[+] Analyzing. This may take a while.\n";


### PR DESCRIPTION
If an audio file is short enough compared to the time step parameter (for example, 98.12 ms on a 10 ms step), the integer division that calculates report_ms_interval becomes zero. When this is used in the modulo arithmetic as a divisor, it throws a SIGFPE. Despite being in the try block, this is not caught as an exception and causes it to core dump.

By ensuring that report_ms_interval is not less than 1, we can avoid this error.